### PR TITLE
feat: enable manual search from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm run deploy
 #### 3. Frontend Deployment (Vercel)
 ```bash
 cd apps/frontend
-# Set VITE_WORKER_URL in .env
+# Set VITE_WORKER_URL and VITE_PI_URL in .env
 npm run build
 npm run deploy
 ```

--- a/apps/frontend/src/store.ts
+++ b/apps/frontend/src/store.ts
@@ -4,15 +4,18 @@ import type { Ticket } from '@egregore/shared';
 interface Store {
   recentTickets: Ticket[];
   workerUrl: string;
+  piUrl: string;
   addTicket: (ticket: Ticket) => void;
   getTicket: (id: string) => Ticket | undefined;
   updateTicket: (id: string, updates: Partial<Ticket>) => void;
   setWorkerUrl: (url: string) => void;
+  setPiUrl: (url: string) => void;
 }
 
 export const useStore = create<Store>((set, get) => ({
   recentTickets: [],
   workerUrl: import.meta.env.VITE_WORKER_URL || 'http://localhost:3001',
+  piUrl: import.meta.env.VITE_PI_URL || 'http://localhost:8080',
   
   addTicket: (ticket) => {
     set((state) => ({
@@ -34,5 +37,9 @@ export const useStore = create<Store>((set, get) => ({
   
   setWorkerUrl: (url) => {
     set({ workerUrl: url });
+  },
+
+  setPiUrl: (url) => {
+    set({ piUrl: url });
   }
 }));


### PR DESCRIPTION
## Summary
- add Pi Agent base URL to frontend store
- wire Search Manuals page to call Pi Agent search API
- document new `VITE_PI_URL` env var

## Testing
- `pnpm test` *(fails: vitest not found / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a62680ac3083239230b16d05a2b135